### PR TITLE
add the matched keys to the search result

### DIFF
--- a/TernarySearchTree.Test/SearchDictionaryTest.cs
+++ b/TernarySearchTree.Test/SearchDictionaryTest.cs
@@ -162,14 +162,14 @@ namespace TernarySearchTree.Test
 
             CollectionAssert.AreEqual(new[]
             {
-                new SearchResult<string>("hörlurarochannat", 3),
-                new SearchResult<string>("hörlurar", 3),
-                new SearchResult<string>("höglurar", 3),
-                new SearchResult<string>("lurarna", 0),
-                new SearchResult<string>("lurer", 1),
-                new SearchResult<string>("lurar", 0),
-                new SearchResult<string>("lurur", 1),
-                new SearchResult<string>("lugercheck", 2),
+                new SearchResult<string>("hörlurarochannat", 3, "hörlurarochannat"),
+                new SearchResult<string>("hörlurar", 3, "hörlurar"),
+                new SearchResult<string>("höglurar", 3, "höglurar"),
+                new SearchResult<string>("lurarna", 0, "lurarna"),
+                new SearchResult<string>("lurer", 1, "lurer"),
+                new SearchResult<string>("lurar", 0, "lurar"),
+                new SearchResult<string>("lurur", 1, "lurur"),
+                new SearchResult<string>("lugercheck", 2, "lugercheck"),
             }.OrderBy(v => v.Value).ToArray(), result);
             
             var resultWithDelete = new SearchDictionary<string>
@@ -177,7 +177,7 @@ namespace TernarySearchTree.Test
                 { "lurcheck", "lurcheck" },
                 { "luarcheck", "luarcheck" }
             }.StartsWith("lurarcheck", 1).OrderBy(v => v.Value).ToArray();
-            CollectionAssert.AreEqual(new[] { new SearchResult<string>("luarcheck", 1) }.OrderBy(v => v.Value).ToArray(), resultWithDelete);
+            CollectionAssert.AreEqual(new[] { new SearchResult<string>("luarcheck", 1, "luarcheck") }.OrderBy(v => v.Value).ToArray(), resultWithDelete);
         }
 
         [TestMethod]

--- a/TernarySearchTree/SearchResult.cs
+++ b/TernarySearchTree/SearchResult.cs
@@ -1,8 +1,10 @@
 ﻿namespace TernarySearchTree;
 
-public struct SearchResult<TValue>(TValue value, int editDistance)
+public struct SearchResult<TValue>(TValue value, int editDistance, string key)
 {
     public TValue Value { get; } = value;
 
     public int EditDistance { get; } = editDistance;
+    
+    public string Key { get; } = key;
 }


### PR DESCRIPTION
Adds not just the value and distance to the result but also the matched key.

f.e. if it is a search tree of integers, the result gave no indication as to what you matched against, only the int value and an edit distance.

Justification for this change is to be able to tweak the searches.
If a search of "bukket" gives the value 32, with edit distance 1, you will now be able to see that a better search with lower distance would have been "bucket"